### PR TITLE
Dependency updates

### DIFF
--- a/playlist.hs
+++ b/playlist.hs
@@ -26,13 +26,13 @@ data Command = CmdURLs Format | CmdConvert Format Format
 --------------------------------------------------------------------------------
 urlCommandOptions :: Parser Command
 urlCommandOptions = CmdURLs
-  <$> option (short 'f' <> long "format" <> metavar "FORMAT" <> help "Input format")
+  <$> option auto (short 'f' <> long "format" <> metavar "FORMAT" <> help "Input format")
 
 --------------------------------------------------------------------------------
 convertCommandOptions :: Parser Command
 convertCommandOptions = CmdConvert
-  <$> option (short 'f' <> long "from" <> metavar "FORMAT" <> help "Input format")
-  <*> option (short 't' <> long "to"   <> metavar "FORMAT" <> help "Output format")
+  <$> option auto (short 'f' <> long "from" <> metavar "FORMAT" <> help "Input format")
+  <*> option auto (short 't' <> long "to"   <> metavar "FORMAT" <> help "Output format")
 
 --------------------------------------------------------------------------------
 commands :: Parser Command

--- a/playlists.cabal
+++ b/playlists.cabal
@@ -111,7 +111,7 @@ executable playlist
 
   build-depends: base
                , bytestring
-               , optparse-applicative >= 0.5 && < 1.0
+               , optparse-applicative >= 0.10.0 && < 0.12.0
                , playlists
                , text
 

--- a/playlists.cabal
+++ b/playlists.cabal
@@ -95,7 +95,7 @@ library
   build-depends: base       >= 4.6   && < 5
                , attoparsec >= 0.10  && < 1.0
                , bytestring >= 0.10  && < 1.0
-               , text       >= 0.11  && < 1.2
+               , text       >= 0.11  && < 1.3
                , word8      >= 0.0   && < 1.0
                , filepath   >= 1.3   && < 2.0
 

--- a/src/Text/Playlist/M3U/Reader.hs
+++ b/src/Text/Playlist/M3U/Reader.hs
@@ -69,4 +69,4 @@ commentOrTitle = do
                  skipSpace
                  text <- decodeUtf8 <$> takeWhile1 (not . isEOL)
                  skipSpace
-                 return $! Just text
+                 return (Just text)


### PR DESCRIPTION
These commits update the package to work with newer versions of optparse-applicative (required an actual code change) and text (just required changing the upper bound in the cabal file).
